### PR TITLE
DEV-0707 - Simpler API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,23 @@ npm install @adtonos/logging
 ```
 
 ### Using
+
+#### Basic usage
+```js
+import { getDefaultLogger } from '@adtonos/logging';
+const logger = getDefaultLogger();
+
+logger.fatal('...');
+logger.error('...');
+logger.warn('...');
+logger.info('...');
+logger.debug('...');
+logger.exception(e);
+
+```
+
+#### Advanced usage
+
 ```js
 import { getLogger, ConsoleHandler } from '@adtonos/logging';
 
@@ -20,14 +37,6 @@ logger.setLevel('DEBUG');
 const consoleHandler = new ConsoleHandler();
 consoleHandler.setFormater(new SimpleFormater('{name} {levelName} {msg}'));
 logger.addHandler(consoleHandler);
-
-
-logger.fatal('...');
-logger.error('...');
-logger.warn('...');
-logger.info('...');
-logger.debug('...');
-logger.exception(e);
 
 // create app child logger
 const dbLogger = getLogger('app.db');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { Manager } from './manager';
 import { ILogger } from './interfaces';
+import { SimpleFormater } from './formaters';
+import { ConsoleHandler } from './handlers';
 export * from './interfaces';
 export { Filter, Filterer } from './filter';
 export { SimpleFormater } from './formaters';
@@ -11,4 +13,20 @@ const manager = new Manager();
 
 export function getLogger(name?: string): ILogger {
   return manager.getLogger(name);
+}
+
+let defaultLogger: ILogger;
+
+export function getDefaultLogger(): ILogger {
+  if (!defaultLogger) {
+    const TARGET = process.env.NODE_ENV || 'devel';
+    const LOG_LEVEL = process.env.LOGLEVEL || (TARGET === 'production' ? 'INFO' : 'DEBUG');
+    defaultLogger = getLogger(process.env.APP_NAME || '');
+    const formatter = new SimpleFormater('{created} - {levelName}: {msg}{exception}{extra}');
+    const consoleHandler = new ConsoleHandler();
+    consoleHandler.setFormater(formatter);
+    consoleHandler.setLevel(LOG_LEVEL);
+    defaultLogger.addHandler(consoleHandler);
+  }
+  return defaultLogger;
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,7 +2,7 @@ import { assert } from 'chai';
 
 import { LEVELS } from '../src/consts';
 import { Manager } from '../src/manager';
-import { Logger, BaseHandler } from '../src/index';
+import { Logger, BaseHandler, getDefaultLogger } from '../src/index';
 
 class TestHandler extends BaseHandler {
   private _body: Array<any>;
@@ -228,5 +228,13 @@ describe('@adtonos/logging :: Handler', () => {
     _dummy(logger);
 
     assert.equal('i,w1,w2,e,c,f', handler.result());
+  });
+});
+
+describe('@adtonos/logging :: getDefaultLogger()', () => {
+  it('should return the same logger every time', () => {
+    const logger1 = getDefaultLogger();
+    const logger2 = getDefaultLogger();
+    assert.strictEqual(logger1, logger2);
   });
 });


### PR DESCRIPTION
This adds a simpler init function: `getDefaultLogger()`. It is meant to be used by libraries to provide a standard logging environment, where the library itself (like `adtonos-utils`) does not need to decide which settings to use.

Advantages over just using `getLogger()`:
* Simpler - no decisions to make. This codifies a standard that was already being used across apps.
* Prevents adding outputs twice - in case two libraries call `getLogger()` and then `.addHandler()`, you could get duplicated lines on output. This prevents that - libraries can rely on defaults, and are free from adding handlers themselves.

Example refactoring + usage: https://github.com/adtonos/adtonos-messaging/commit/d1e15cbc9f8d27b762328ffa220388fb9278047d